### PR TITLE
Pass current time to solidification events update

### DIFF
--- a/src/Finch_Run.hpp
+++ b/src/Finch_Run.hpp
@@ -101,7 +101,7 @@ class Layer
         // communicate halos
         grid.gather();
 
-        solidification_data_.update( grid );
+        solidification_data_.update( grid, time );
 
         // Write the current temperature field (or, if n = num_steps - 1,
         // write the final temperature field)


### PR DESCRIPTION
Fixup of #5 - the local copy `_time` in `SolidificationData` was not updated when `update` was called, as a result, it had a value of 0 for all events and lead to negative `tm` and `tl` values. `_time` is no longer stored in `SolidificationData`, instead the current value of `time` is passed to `update` each time step