### PR TITLE
Allow intermediate output to be turned off

### DIFF
--- a/src/Finch_Inputs.hpp
+++ b/src/Finch_Inputs.hpp
@@ -35,6 +35,27 @@ namespace Finch
     if ( comm_rank == 0 )                                                      \
     std::cout
 
+struct Output
+{
+    int total_steps;
+    int interval;
+
+    void setInterval( const int num_steps )
+    {
+        // If total_output_steps = 0, set increment to greater than the number
+        // of time steps to avoid printing output, otherwise bound
+        // output_interval to be greater than 1 and no larger than the total
+        // number of time steps
+        if ( total_steps == 0 )
+            interval = num_steps + 1;
+        else
+        {
+            interval = static_cast<int>( ( num_steps / total_steps ) );
+            interval = std::max( std::min( interval, num_steps ), 1 );
+        }
+    }
+};
+
 struct Time
 {
     double Co;
@@ -42,11 +63,9 @@ struct Time
     double end_time;
     double time_step;
     double time;
-    int total_output_steps;
-    int total_monitor_steps;
     int num_steps;
-    int output_interval;
-    int monitor_interval;
+    Output output;
+    Output monitor;
 };
 
 struct Space
@@ -103,7 +122,7 @@ struct TimeMonitor
     {
         start_time = std::chrono::high_resolution_clock::now();
         MPI_Comm_rank( comm, &comm_rank );
-        total_monitor_steps = time.total_monitor_steps;
+        total_monitor_steps = time.monitor.total_steps;
         num_steps = time.num_steps;
     }
 
@@ -172,8 +191,8 @@ class Inputs
         Info << "  Co: " << time.Co << std::endl;
         Info << "  Start Time: " << time.start_time << std::endl;
         Info << "  End Time: " << time.end_time << std::endl;
-        Info << "  Num Output Steps: " << time.total_output_steps << std::endl;
-        Info << "  Num Monitor Steps: " << time.total_monitor_steps
+        Info << "  Num Output Steps: " << time.output.total_steps << std::endl;
+        Info << "  Num Monitor Steps: " << time.monitor.total_steps
              << std::endl;
 
         // Print space
@@ -268,33 +287,8 @@ class Inputs
         time.num_steps = static_cast<int>( ( time.end_time - time.start_time ) /
                                            ( time.time_step ) );
 
-        // If total_output_steps = 0, set increment to greater than the number
-        // of time steps to avoid printing output, otherwise bound
-        // output_interval to be greater than 1 and no larger than the total
-        // number of time steps
-        if ( time.total_output_steps == 0 )
-            time.output_interval = time.num_steps + 1;
-        else
-        {
-            time.output_interval = static_cast<int>(
-                ( time.num_steps / time.total_output_steps ) );
-            time.output_interval =
-                std::max( std::min( time.output_interval, time.num_steps ), 1 );
-        }
-
-        // If total_monitor_steps = 0, set increment to greater than the number
-        // of time steps to avoid printing output, otherwise bound
-        // monitor_interval to be greater than 1 and no larger than the total
-        // number of time steps
-        if ( time.total_monitor_steps == 0 )
-            time.monitor_interval = time.num_steps + 1;
-        else
-        {
-            time.monitor_interval = static_cast<int>(
-                ( time.num_steps / time.total_monitor_steps ) );
-            time.monitor_interval = std::max(
-                std::min( time.monitor_interval, time.num_steps ), 1 );
-        }
+        time.output.setInterval( time.num_steps );
+        time.monitor.setInterval( time.num_steps );
 
         // initialize time monitoring
         time_monitor = TimeMonitor( comm, time );
@@ -310,8 +304,8 @@ class Inputs
         time.Co = db["time"]["Co"];
         time.start_time = db["time"]["start_time"];
         time.end_time = db["time"]["end_time"];
-        time.total_output_steps = db["time"]["total_output_steps"];
-        time.total_monitor_steps = db["time"]["total_monitor_steps"];
+        time.output.total_steps = db["time"]["total_output_steps"];
+        time.monitor.total_steps = db["time"]["total_monitor_steps"];
 
         // Read space components
         space.initial_temperature = db["space"]["initial_temperature"];

--- a/src/Finch_Inputs.hpp
+++ b/src/Finch_Inputs.hpp
@@ -178,12 +178,6 @@ class Inputs
 
     void write()
     {
-        Info << "  Co: " << time.Co << std::endl;
-        Info << "  Start Time: " << time.start_time << std::endl;
-        Info << "  End Time: " << time.end_time << std::endl;
-        Info << "  Num Output Steps: " << time.total_output_steps << std::endl;
-        Info << "  Num Monitor Steps: " << time.total_monitor_steps
-             << std::endl;
         Info << "Simulation will be performed using parameters: " << std::endl;
 
         // Print time

--- a/src/Finch_Inputs.hpp
+++ b/src/Finch_Inputs.hpp
@@ -268,11 +268,12 @@ class Inputs
         time.num_steps = static_cast<int>( ( time.end_time - time.start_time ) /
                                            ( time.time_step ) );
 
-        // If total_output_steps = 0, print only the final temperature field,
-        // otherwise bound output_interval as larger than 0 but no larger than
-        // the total number of time steps
+        // If total_output_steps = 0, set increment to greater than the number
+        // of time steps to avoid printing output, otherwise bound
+        // output_interval to be greater than 1 and no larger than the total
+        // number of time steps
         if ( time.total_output_steps == 0 )
-            time.output_interval = time.num_steps;
+            time.output_interval = time.num_steps + 1;
         else
         {
             time.output_interval = static_cast<int>(
@@ -281,11 +282,12 @@ class Inputs
                 std::max( std::min( time.output_interval, time.num_steps ), 1 );
         }
 
-        // If total_monitor_steps = 0, do not print time step or current
-        // runtime, otherwise bound monitor_interval as larger than 0 but no
-        // larger than the total number of time steps
+        // If total_monitor_steps = 0, set increment to greater than the number
+        // of time steps to avoid printing output, otherwise bound
+        // monitor_interval to be greater than 1 and no larger than the total
+        // number of time steps
         if ( time.total_monitor_steps == 0 )
-            time.monitor_interval = time.num_steps;
+            time.monitor_interval = time.num_steps + 1;
         else
         {
             time.monitor_interval = static_cast<int>(

--- a/src/Finch_Run.hpp
+++ b/src/Finch_Run.hpp
@@ -49,7 +49,7 @@ class Layer
         double& time = inputs.time.time;
         int num_steps = inputs.time.num_steps;
         double dt = inputs.time.time_step;
-        int output_interval = inputs.time.output_interval;
+        int output_interval = inputs.time.output.interval;
 
         // update the temperature field
         for ( int n = 0; n < num_steps; ++n )
@@ -59,7 +59,7 @@ class Layer
             step( exec_space, n, time, dt, output_interval, grid, beam, fd );
 
             // Update time monitoring
-            if ( ( n + 1 ) % inputs.time.monitor_interval == 0 )
+            if ( ( n + 1 ) % inputs.time.monitor.interval == 0 )
             {
                 inputs.time_monitor.write( n );
             }

--- a/src/Finch_Run.hpp
+++ b/src/Finch_Run.hpp
@@ -56,15 +56,12 @@ class Layer
         {
             inputs.time_monitor.update();
 
-            step( exec_space, n, time, num_steps, dt, output_interval, grid,
-                  beam, fd );
+            step( exec_space, n, time, dt, output_interval, grid, beam, fd );
 
-            // Update time monitoring (or, if n = num_steps - 1, write the
-            // final solution time)
-            if ( ( ( n + 1 ) % inputs.time.monitor_interval == 0 ) ||
-                 ( n == num_steps - 1 ) )
+            // Update time monitoring
+            if ( ( n + 1 ) % inputs.time.monitor_interval == 0 )
             {
-                inputs.time_monitor.write( n + 1 );
+                inputs.time_monitor.write( n );
             }
         }
     }
@@ -72,7 +69,7 @@ class Layer
     // Run a single timestep
     template <typename ExecutionSpace, typename SolverType>
     void step( ExecutionSpace exec_space, const int n, double& time,
-               const int num_steps, const double dt, const int output_interval,
+               const double dt, const int output_interval,
                Grid<MemorySpace> grid, MovingBeam& beam, SolverType& fd )
     {
         time += dt;
@@ -103,9 +100,8 @@ class Layer
 
         solidification_data_.update( grid, time );
 
-        // Write the current temperature field (or, if n = num_steps - 1,
-        // write the final temperature field)
-        if ( ( ( n + 1 ) % output_interval == 0 ) || ( n == num_steps - 1 ) )
+        // Write the current temperature field
+        if ( ( n + 1 ) % output_interval == 0 )
         {
             grid.output( n + 1, ( n + 1 ) * dt );
         }

--- a/src/Finch_Run.hpp
+++ b/src/Finch_Run.hpp
@@ -56,20 +56,25 @@ class Layer
         {
             inputs.time_monitor.update();
 
-            step( exec_space, n, time, dt, output_interval, grid, beam, fd );
+            step( exec_space, time, dt, grid, beam, fd );
 
             // Update time monitoring
             if ( ( n + 1 ) % inputs.time.monitor.interval == 0 )
             {
                 inputs.time_monitor.write( n );
             }
+
+            // Write the current temperature field
+            if ( ( n + 1 ) % output_interval == 0 )
+            {
+                grid.output( n, n * dt );
+            }
         }
     }
 
     // Run a single timestep
     template <typename ExecutionSpace, typename SolverType>
-    void step( ExecutionSpace exec_space, const int n, double& time,
-               const double dt, const int output_interval,
+    void step( ExecutionSpace exec_space, double& time, const double dt,
                Grid<MemorySpace> grid, MovingBeam& beam, SolverType& fd )
     {
         time += dt;
@@ -99,12 +104,6 @@ class Layer
         grid.gather();
 
         solidification_data_.update( grid, time );
-
-        // Write the current temperature field
-        if ( ( n + 1 ) % output_interval == 0 )
-        {
-            grid.output( n + 1, ( n + 1 ) * dt );
-        }
     }
 
     auto getSolidificationData() { return solidification_data_.get(); }


### PR DESCRIPTION
Previously, even an increment of 0 would print output on the last time step - this allows that to be avoided