### PR TITLE
Member function to obtain x,y,z bounds of region that melts/resolidifies

### DIFF
--- a/applications/SingleLayer.cpp
+++ b/applications/SingleLayer.cpp
@@ -50,6 +50,7 @@ void run( int argc, char* argv[] )
 
     // Write the temperature data used by ExaCA/other post-processing
     app.writeSolidificationData();
+    app.getSolidificationDataBounds();
 }
 
 int main( int argc, char* argv[] )

--- a/src/Finch_Run.hpp
+++ b/src/Finch_Run.hpp
@@ -109,6 +109,11 @@ class Layer
     auto getSolidificationData() { return solidification_data_.get(); }
 
     auto writeSolidificationData() { return solidification_data_.write(); }
+
+    auto getSolidificationDataBounds()
+    {
+        return solidification_data_.getBounds();
+    }
 };
 
 } // namespace Finch

--- a/src/Finch_SolidificationData.hpp
+++ b/src/Finch_SolidificationData.hpp
@@ -267,7 +267,7 @@ class SolidificationData
         fout.close();
     }
 
-    std::vector<double> getBounds()
+    Kokkos::Array<double, 6> getBounds()
     {
         // Local copies for lambda capture
         auto events_ = events;
@@ -303,7 +303,7 @@ class SolidificationData
             Kokkos::Max<double>( y_max ), Kokkos::Max<double>( z_max ) );
 
         // Get the min/max bounds on each direction across all ranks
-        std::vector<double> finch_data_bounds( 6 );
+        Kokkos::Array<double, 6> finch_data_bounds;
         MPI_Allreduce( &x_min, &finch_data_bounds[0], 1, MPI_DOUBLE, MPI_MIN,
                        MPI_COMM_WORLD );
         MPI_Allreduce( &y_min, &finch_data_bounds[1], 1, MPI_DOUBLE, MPI_MIN,
@@ -321,15 +321,15 @@ class SolidificationData
         {
             std::cout
                 << "Min/Max X bounds of the melted/resolidified region were "
-                << finch_data_bounds[0] << " / " << finch_data_bounds[1]
+                << finch_data_bounds[0] << " / " << finch_data_bounds[3]
                 << std::endl;
             std::cout
                 << "Min/Max Y bounds of the melted/resolidified region were "
-                << finch_data_bounds[2] << " / " << finch_data_bounds[3]
+                << finch_data_bounds[1] << " / " << finch_data_bounds[4]
                 << std::endl;
             std::cout
                 << "Min/Max Z bounds of the melted/resolidified region were "
-                << finch_data_bounds[4] << " / " << finch_data_bounds[5]
+                << finch_data_bounds[2] << " / " << finch_data_bounds[5]
                 << std::endl;
         }
         return finch_data_bounds;


### PR DESCRIPTION
Will allow the option for coupled Finch-ExaCA runs to encompass only the [x,y,z] region that bounds the solidification data. Currently, ExaCA runs use the same bounds as Finch for coupled simulations, which forces ExaCA to allocate memory for cells that do not undergo solidification